### PR TITLE
Update Alpine Dotnet installation script to use dotnet-install.sh directly

### DIFF
--- a/src/alpine-dotnet/install.sh
+++ b/src/alpine-dotnet/install.sh
@@ -20,7 +20,7 @@ chmod +x dotnet-install.sh
 
 # Install 
 
-`./dotnet-install.sh --channel 9.0.1xx --quality preview`
+. ./dotnet-install.sh --channel 9.0.1xx --quality preview
 
 # echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
 # echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' >> ~/.bashrc


### PR DESCRIPTION
This pull request updates the Alpine Dotnet installation script to use dotnet-install.sh directly instead of executing it as a command. This change ensures that the script is executed correctly and improves the overall installation process.